### PR TITLE
Add bml file for new BSNES support

### DIFF
--- a/Mega Man X3 (Manifest for BSNES) [RENAME TO ROM NAME IN ROM FOLDER].bml
+++ b/Mega Man X3 (Manifest for BSNES) [RENAME TO ROM NAME IN ROM FOLDER].bml
@@ -1,0 +1,41 @@
+game
+  label:    Mega Man X3 - Zero Project
+  region:   NTSC
+  board:    HITACHI-LOROM-RAM
+    memory
+      type: ROM
+      size: 0x400000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+    memory
+      type: ROM
+      size: 0xc00
+      content: Data
+      manufacturer: Hitachi
+      architecture: HG51BS169
+      identifier: Cx4
+    memory
+      type: RAM
+      size: 0xc00
+      content: Data
+      manufacturer: Hitachi
+      architecture: HG51BS169
+      identifier: Cx4
+      volatile
+    oscillator
+      frequency: 20000000
+
+board: HITACHI-LOROM-RAM
+  processor architecture=HG51BS169
+    map address=00-3f,80-bf:6c00-6fff,7c00-7fff
+    memory type=ROM content=Program
+      map address=00-7d,80-ff:8000-ffff mask=0x8000
+    memory type=RAM content=Save
+      map address=70-7d,f0-ff:0000-7fff mask=0x8000
+    memory type=ROM content=Data architecture=HG51BS169
+    memory type=RAM content=Data architecture=HG51BS169
+      map address=00-3f,80-bf:6000-6bff,7000-7bff mask=0xf000
+    oscillator


### PR DESCRIPTION
- closes #7 

This wouldn't be required if it weren't for the fact that new bsnes does not know the `HITACHI-LOROM-RAM` board by default, which means it'll fail to load this rom.
This bml file adds the definition for this board, while the entire `game` node is basically just a copy of what bsnes heuristically determines itself (needs to be included though because specifying just the board alone is not possible).