### PR TITLE
Apply Tunnel Rhino fix to BossDoors_ClearVariousEnemyData

### DIFF
--- a/MMX3_NewCode_Locations.asm
+++ b/MMX3_NewCode_Locations.asm
@@ -7553,6 +7553,7 @@ BossDoors_ClearVariousEnemyData:
 	STZ $000E,x ;Blanks out ???
 	STZ $0027,x ;Blanks out ???
 	STZ $0037,x ;Blanks out damage timer
+	STZ $003D,x ;Blanks out counter for Tunnel Rhino's drills
 	TXA
 	CLC
 	ADC #$0040

--- a/MMX3_NewCode_Locations.asm
+++ b/MMX3_NewCode_Locations.asm
@@ -7564,23 +7564,23 @@ BossDoors_ClearVariousEnemyData:
 	RTL
 }
 ; or here's the original fix I came up with, the "nuclear" option; wipes the whole table,
-; eight bytes at a time. in theory, it's slower, but from a player perspective, not by much
+; eight bytes at a time. it's slower (8x by cycle count), but from a player perspective, not by much
 ;{
-	REP #$30
-	LDX #$0D18
-	BossDoors_StartClearing:
-	STZ $0000,X
-	STZ $0002,X
-	STZ $0004,X
-	STZ $0006,X
-	TXA 
-	CLC 
-	ADC #$0008
-	TAX 
-	CMP #$10D8
-	BCC BossDoors_StartClearing
-	SEP #$30
-	RTL 
+;	REP #$30
+;	LDX #$0D18
+;	BossDoors_StartClearing:
+;	STZ $0000,X
+;	STZ $0002,X
+;	STZ $0004,X
+;	STZ $0006,X
+;	TXA 
+;	CLC 
+;	ADC #$0008
+;	TAX 
+;	CMP #$10D8
+;	BCC BossDoors_StartClearing
+;	SEP #$30
+;	RTL 
 ;}
 
 	

--- a/MMX3_NewCode_Locations.asm
+++ b/MMX3_NewCode_Locations.asm
@@ -7563,6 +7563,26 @@ BossDoors_ClearVariousEnemyData:
 	SEP #$30
 	RTL
 }
+; or here's the original fix I came up with, the "nuclear" option; wipes the whole table,
+; eight bytes at a time. in theory, it's slower, but from a player perspective, not by much
+;{
+	REP #$30
+	LDX #$0D18
+	BossDoors_StartClearing:
+	STZ $0000,X
+	STZ $0002,X
+	STZ $0004,X
+	STZ $0006,X
+	TXA 
+	CLC 
+	ADC #$0008
+	TAX 
+	CMP #$10D8
+	BCC BossDoors_StartClearing
+	SEP #$30
+	RTL 
+;}
+
 	
 ;*********************************************************************************
 ; Creates a damage table switch value for Worm Seeker mid-boss in Neon Tiger's level


### PR DESCRIPTION
Adds a fix to a bug from the original game where Tunnel Rhino couldn't use his drill projectiles sometimes.
His routines check offset $3D in his table entry (if he's the first/only entry in the table, that's $D55) for number of drills currently on screen, but neither they nor the door routines clear it beforehand and if the value stored there is non-zero, he skips the "fire drills" logic.

My original solution was to just blank out the whole table in RAM (which is what I posted to romhacking.net and have included here in the comments), but after discovering you are replacing the function anyway, I just added a new STZ to the new function.